### PR TITLE
znu 2.0.1 --> 2.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "zingo-netutils"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "http",
  "http-body-util",


### PR DESCRIPTION
Because Cargo.lock is checked in.