### PR TITLE
release zingo_common_components 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "zingo_common_components"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "hex",
 ]

--- a/zingo_common_components/CHANGELOG.md
+++ b/zingo_common_components/CHANGELOG.md
@@ -15,6 +15,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.3.1] 2026-06-07
+
+### Deprecated
+
+### Added
+
+- `protocol::BlockHeight`: block height type with arithmetic, ordering, and
+  numeric conversions (incl. `H0`, `from_u32`, `saturating_sub`).
+- `protocol::TxId`: transaction identifier type with `read`/`write`,
+  `is_null`, `NULL`, and `from_bytes`.
+- `protocol::ActivationHeights::nu6_2` and
+  `protocol::ActivationHeights::set_nu6_2`: NU6.2 activation height support.
+
+### Changed
+
+### Removed
+
 ## [0.3.0] 2026-02-26
 
 ### Deprecated

--- a/zingo_common_components/Cargo.toml
+++ b/zingo_common_components/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://github.com/zingolabs/zingo-common"
 homepage = "https://github.com/zingolabs/zingo-common"
 repository = "https://github.com/zingolabs/zingo-common.git"
 
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "MIT"
 


### PR DESCRIPTION
  Backwards-compatible (additive) release. Per cargo semver for a 0.y.z
  crate, a compatible change bumps the patch component, so 0.3.0 -> 0.3.1.

  Added (protocol):
  - BlockHeight type (arithmetic, ordering, numeric conversions)
  - TxId type (read/write, is_null, NULL, from_bytes)
  - ActivationHeights::nu6_2 / set_nu6_2 (NU6.2 activation height support)

  Unblocks zaino PR #1181, which can drop its temporary git-rev pin once
  this is tagged and published.